### PR TITLE
Remove webpack zip plugin and rename workflow

### DIFF
--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -1,4 +1,4 @@
-name: Node.js CI
+name: Build extension
 
 on:
   push:

--- a/package-lock.json
+++ b/package-lock.json
@@ -3535,12 +3535,6 @@
         "isarray": "^1.0.0"
       }
     },
-    "buffer-crc32": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npm.taobao.org/buffer-crc32/download/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
-      "dev": true
-    },
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npm.taobao.org/buffer-from/download/buffer-from-1.1.1.tgz",
@@ -12906,25 +12900,6 @@
       "requires": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
-      }
-    },
-    "yazl": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npm.taobao.org/yazl/download/yazl-2.5.1.tgz",
-      "integrity": "sha1-o9ZdPdZZpbCTeFDoYJ8i//orXDU=",
-      "dev": true,
-      "requires": {
-        "buffer-crc32": "~0.2.3"
-      }
-    },
-    "zip-webpack-plugin": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npm.taobao.org/zip-webpack-plugin/download/zip-webpack-plugin-3.0.0.tgz",
-      "integrity": "sha1-Y7PBc/GoegBpFc1zKKPEC0TcjjI=",
-      "dev": true,
-      "requires": {
-        "webpack-sources": "^1.1.0",
-        "yazl": "^2.4.3"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -40,8 +40,7 @@
     "webpack": "^4.44.0",
     "webpack-cli": "^3.3.12",
     "webpack-extension-reloader": "^1.1.4",
-    "webpack-merge": "^5.0.9",
-    "zip-webpack-plugin": "^3.0.0"
+    "webpack-merge": "^5.0.9"
   },
   "dependencies": {
     "prop-types": "^15.7.2",

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -1,12 +1,6 @@
 const { merge } = require('webpack-merge');
-const ZipPlugin = require('zip-webpack-plugin');
 const common = require('./webpack.config.common');
 
 module.exports = merge(common, {
   mode: 'production',
-  plugins: [
-    new ZipPlugin({
-      filename: 'dist.zip',
-    }),
-  ],
 });


### PR DESCRIPTION
Github workflow will zip uploaded dist folder automatically, there is no need to zip dist in webpack build process.